### PR TITLE
Improve student activity registration system

### DIFF
--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -1,0 +1,32 @@
+name: Backend Pytest CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Create virtual environment
+        run: python -m venv .venv
+
+      - name: Install dependencies
+        run: |
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          . .venv/bin/activate
+          python -m pytest -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,20 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is currently signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball league and practice",
+        "schedule": "Mondays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and compete in matches",
+        "schedule": "Wednesdays and Saturdays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["sarah@mergington.edu", "alex@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and visual arts",
+        "schedule": "Tuesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["grace@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Perform in plays and musicals throughout the year",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["nathan@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["lucas@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["ava@mergington.edu", "mason@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,7 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
@@ -78,25 +78,34 @@ activities = {
 }
 
 
+def get_activities_store():
+    """Return the activity store dependency for route handlers."""
+    return activities
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(activity_store=Depends(get_activities_store)):
+    return activity_store
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    activity_store=Depends(get_activities_store),
+):
     """Sign up a student for an activity"""
     # Validate activity exists
-    if activity_name not in activities:
+    if activity_name not in activity_store:
         raise HTTPException(status_code=404, detail="Activity not found")
 
     # Get the specific activity
-    activity = activities[activity_name]
+    activity = activity_store[activity_name]
 
     # Validate student is not already signed up
     if email in activity["participants"]:
@@ -108,13 +117,17 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/participants")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    activity_store=Depends(get_activities_store),
+):
     """Unregister a student from an activity"""
     # Validate activity exists
-    if activity_name not in activities:
+    if activity_name not in activity_store:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    activity = activities[activity_name]
+    activity = activity_store[activity_name]
 
     # Validate student is currently signed up
     if email not in activity["participants"]:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,28 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function showMessage(message, type) {
+    messageDiv.textContent = message;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch(`/activities?ts=${Date.now()}`, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error("Failed to fetch activities");
+      }
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -20,11 +34,36 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        let participantsHTML = "";
+        if (details.participants.length > 0) {
+          details.participants.forEach((participant) => {
+            participantsHTML += `
+              <li class="participant-item">
+                <span class="participant-email">${participant}</span>
+                <button
+                  type="button"
+                  class="participant-remove"
+                  data-activity="${name}"
+                  data-email="${participant}"
+                  aria-label="Remove ${participant} from ${name}"
+                  title="Unregister participant"
+                >&#128465;</button>
+              </li>
+            `;
+          });
+        } else {
+          participantsHTML = '<li class="participant-empty">No participants yet</li>';
+        }
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants</strong></p>
+            <ul class="participants-list" aria-label="Participants for ${name}">${participantsHTML}</ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -59,25 +98,54 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".participant-remove");
+    if (!removeButton) {
+      return;
+    }
+
+    const activity = removeButton.dataset.activity;
+    const email = removeButton.dataset.email;
+
+    if (!activity || !email) {
+      return;
+    }
+
+    removeButton.disabled = true;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+        await fetchActivities();
+      } else {
+        showMessage(result.detail || "Could not unregister participant", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to unregister participant. Please try again.", "error");
+      console.error("Error unregistering participant:", error);
+    } finally {
+      removeButton.disabled = false;
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,80 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #eef3ff 0%, #f7faff 100%);
+  border: 1px solid #d8e2ff;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #243b7c;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #304776;
+  word-break: break-word;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.participant-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid #f1b5b8;
+  background-color: #fff3f3;
+  color: #a32028;
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.participant-remove:hover {
+  background-color: #ffdcdc;
+  transform: scale(1.05);
+}
+
+.participant-remove:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participant-empty {
+  color: #5d6f99;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app, get_activities_store
+
+
+@pytest.fixture
+def test_activity_store():
+    return copy.deepcopy(activities)
+
+
+@pytest.fixture
+def client(test_activity_store):
+    def override_activity_store():
+        return test_activity_store
+
+    app.dependency_overrides[get_activities_store] = override_activity_store
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,117 @@
+def test_get_activities_returns_activity_map(client):
+    # Arrange
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+
+
+def test_signup_for_activity_adds_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    participants = activities_response.json()[activity_name]["participants"]
+    assert email in participants
+
+
+def test_signup_for_activity_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Student already signed up for this activity"}
+
+
+def test_signup_for_activity_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_unregister_from_activity_removes_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Unregistered {email} from {activity_name}"}
+    participants = activities_response.json()[activity_name]["participants"]
+    assert email not in participants
+
+
+def test_unregister_from_activity_returns_not_found_for_non_member(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not-enrolled@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Student is not signed up for this activity"}
+
+
+def test_unregister_from_activity_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_each_test_starts_with_clean_activity_state(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "isolation-check@mergington.edu"
+
+    # Act
+    initial_activities = client.get("/activities")
+
+    # Assert
+    participants = initial_activities.json()[activity_name]["participants"]
+    assert email not in participants


### PR DESCRIPTION
This pull request introduces major improvements to the extracurricular activities app, including new backend functionality, frontend enhancements, automated testing, and CI integration. The changes add support for unregistering participants from activities, improve the user interface to manage participants, and introduce robust testing and CI workflows to ensure code quality.

**Backend functionality enhancements:**

* Added a DELETE endpoint `/activities/{activity_name}/participants` to allow unregistering a student from an activity, including validation for activity existence and participant membership. Also refactored the activities store to use FastAPI dependency injection for better testability and modularity.
* Expanded the sample activities dataset with additional clubs and teams, providing a richer set of activities for users to interact with.

**Frontend improvements:**

* Updated the frontend (`src/static/app.js`) to display participants for each activity, allow unregistering participants via a remove button, and show feedback messages for signup and unregister actions. Added a utility to prevent caching when fetching activities. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R28) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R37-R66) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R148)
* Enhanced the UI styling for participant lists and remove buttons to provide a clear, user-friendly interface for managing activity participants.

**Testing and CI:**

* Added comprehensive backend tests for activity signup, duplicate prevention, unregistering, and error cases, along with a test fixture to isolate activity state between tests. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R24) [[2]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R117)
* Introduced a GitHub Actions workflow (`.github/workflows/ci-pytest.yml`) to automatically run backend tests on pull requests and pushes, and updated `pytest.ini` to specify test paths. [[1]](diffhunk://#diff-a619fd5a65a583817b873a0ff1a33401d620b29407a8a233f96dddf3798e8df2R1-R32) [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R3)